### PR TITLE
Turn off fPIC in NCEP_crtm

### DIFF
--- a/NCEP_crtm/CMakeLists.txt
+++ b/NCEP_crtm/CMakeLists.txt
@@ -147,3 +147,5 @@ endif ()
 esma_add_library (${this}
   SRCS ${SRCS}
   )
+
+set_target_properties(${this} PROPERTIES POSITION_INDEPENDENT_CODE OFF)


### PR DESCRIPTION
Per @bena-nasa, the c48f 3dvar ADAS run is non-zero-diff if `NCEP_crtm`
is compiled with fPIC. While this isn't what is wanted long-term, for
now we turn it off. An issue will be filed to eventually re-enable this
as it points to a more intrinsic issue in the library