### PR TITLE
Updates to allow GEOS to build without MKL

### DIFF
--- a/NCEP_gfsio/CMakeLists.txt
+++ b/NCEP_gfsio/CMakeLists.txt
@@ -2,7 +2,19 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS gfsio_module.f90 gfsio_solve_axb.F90
-  DEPENDENCIES GMAO_mpeu NCEP_bacio_r4i4 NCEP_w3_r4i4 ${MKL_LIBRARIES}
+  DEPENDENCIES GMAO_mpeu NCEP_bacio_r4i4 NCEP_w3_r4i4
   )
+
+if (APPLE)
+   set(MKL_Fortran TRUE)
+endif ()
+find_package(MKL)
+if (MKL_FOUND)
+   set(BLA_VENDOR Intel10_64lp_seq)
+   target_link_libraries(${this} PRIVATE ${MKL_LIBRARIES})
+else ()
+   find_package(LAPACK REQUIRED)
+   target_link_libraries(${this} PRIVATE ${LAPACK_LIBRARIES})
+endif ()
 
 set (CMAKE_Fortran_FLAGS_RELEASE "-O3 ${BIG_ENDIAN} ${common_Fortran_flags} ${GEOS_Fortran_Release_FPE_Flags} ${ALIGNCOM}")

--- a/NCEP_sp/CMakeLists.txt
+++ b/NCEP_sp/CMakeLists.txt
@@ -18,7 +18,11 @@ set (CMAKE_Fortran_FLAGS_RELEASE "-O2 ${GEOS_Fortran_Release_FPE_Flags} ${EXTEND
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES NCEP_w3_${precision})
 
-target_link_libraries(${this} PUBLIC ${LAPACK_LIBRARIES})
+if (MKL_FOUND)
+   target_link_libraries(${this} PUBLIC ${MKL_LIBRARIES})
+else ()
+   target_link_libraries(${this} PUBLIC ${LAPACK_LIBRARIES})
+endif ()
 
 if (precision MATCHES "r4i4")
   # use default real/int precisions

--- a/NCEP_sp/CMakeLists.txt
+++ b/NCEP_sp/CMakeLists.txt
@@ -18,10 +18,16 @@ set (CMAKE_Fortran_FLAGS_RELEASE "-O2 ${GEOS_Fortran_Release_FPE_Flags} ${EXTEND
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES NCEP_w3_${precision})
 
+if (APPLE)
+   set(MKL_Fortran TRUE)
+endif ()
+find_package(MKL)
 if (MKL_FOUND)
-   target_link_libraries(${this} PUBLIC ${MKL_LIBRARIES})
+   set(BLA_VENDOR Intel10_64lp_seq)
+   target_link_libraries(${this} PRIVATE ${MKL_LIBRARIES})
 else ()
-   target_link_libraries(${this} PUBLIC ${LAPACK_LIBRARIES})
+   find_package(LAPACK REQUIRED)
+   target_link_libraries(${this} PRIVATE ${LAPACK_LIBRARIES})
 endif ()
 
 if (precision MATCHES "r4i4")

--- a/NCEP_sp/CMakeLists.txt
+++ b/NCEP_sp/CMakeLists.txt
@@ -18,7 +18,7 @@ set (CMAKE_Fortran_FLAGS_RELEASE "-O2 ${GEOS_Fortran_Release_FPE_Flags} ${EXTEND
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES NCEP_w3_${precision})
 
-target_link_libraries(${this} PUBLIC ${MKL_LIBRARIES})
+target_link_libraries(${this} PUBLIC ${LAPACK_LIBRARIES})
 
 if (precision MATCHES "r4i4")
   # use default real/int precisions


### PR DESCRIPTION
This set of PRs is to allow GEOS to build without MKL. Note that it currently does this by making RRTMGP unusable if MKL is not found. This is not ideal, but it's a first attempt.

Should be taken in concert with:
~https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/321~
~https://github.com/GEOS-ESM/ESMA_cmake/pull/115~

ETA: Turns out thanks to CMake knowledge of @tclune this is no longer true! Since each component specifies what they need, they are now independent!