### PR TITLE
Add Docker authentication for pulls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     docker:
       - image: gmao/ubuntu20-geos-env-mkl:6.0.16-openmpi_4.0.5-gcc_10.2.0
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_AUTH_TOKEN
     resource_class: xlarge
     working_directory: /root/project
     steps:


### PR DESCRIPTION
Per Docker, soon there will be [limits on unauthenticated pulls](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/). CircleCI recommends using contexts to authenticate. This PR adds the authentication