### PR TITLE
Update CI to use orb and modern baselibs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,60 +1,25 @@
 version: 2.1
 
-executors:
-  gcc-build-env:
-    docker:
-      - image: gmao/ubuntu20-geos-env-mkl:v6.2.8-openmpi_4.0.6-gcc_11.2.0
-        auth:
-          username: $DOCKERHUB_USER
-          password: $DOCKERHUB_AUTH_TOKEN
-    environment:
-      OMPI_ALLOW_RUN_AS_ROOT: 1
-      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-      OMPI_MCA_btl_vader_single_copy_mechanism: none
-    resource_class: large
-    #MEDIUM# resource_class: medium
+# Anchors to prevent forgetting to update a version
+baselibs_version: &baselibs_version v7.6.1
+bcs_version: &bcs_version v10.23.0
+
+orbs:
+  ci: geos-esm/circleci-tools@1
 
 workflows:
-  version: 2.1
-  build-test:
+  build-and-test:
     jobs:
-      - build-GEOSgcm:
+      # Build GEOSgcm
+      - ci/build:
+          name: build-GEOSgcm-on-<< matrix.compiler >>
           context:
             - docker-hub-creds
-
-jobs:
-  build-GEOSgcm:
-    executor: gcc-build-env
-    working_directory: /root/project
-    steps:
-      - run:
-          name: "NCEP_Shared branch"
-          command: echo ${CIRCLE_BRANCH}
-      - checkout
-      - run:
-          name: "Checkout GEOSgcm fixture and update NCEP_Shared branch"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}
-            git clone git@github.com:GEOS-ESM/GEOSgcm.git
-            cd GEOSgcm
-            mepo init
-            mepo clone
-            mepo develop GEOSgcm_GridComp GEOSgcm_App
-            if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "master" ] && [ "${CIRCLE_BRANCH}" != "main" ]
-            then
-               mepo checkout-if-exists ${CIRCLE_BRANCH}
-            fi
-            mepo status
-      - run:
-          name: "CMake"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/GEOSgcm
-            mkdir build
-            cd build
-            cmake .. -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_BUILD_TYPE=Debug
-      - run:
-          name: "Build"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/GEOSgcm/build
-            make -j"$(nproc)" install
-            #MEDIUM# make -j4 install
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
+          baselibs_version: *baselibs_version
+          repo: GEOSgcm
+          checkout_fixture: true
+          mepodevelop: true
+          persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra


### PR DESCRIPTION
The CI in NCEP_Shared is quite old. This PR updates it to be more like the rest of GEOS.