### PR TITLE
missing line from prior merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 # Anchors to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.6.1
+baselibs_version: &baselibs_version v7.7.0
 bcs_version: &bcs_version v10.23.0
 
 orbs:

--- a/NCEP_crtm/CMakeLists.txt
+++ b/NCEP_crtm/CMakeLists.txt
@@ -146,6 +146,7 @@ set (SRCS
 )
 
 if (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+  set (CMAKE_Fortran_FLAGS_RELEASE "-free ${FOPT2} ${LITTLE_ENDIAN} ${BYTERECLEN}")
   if (CMAKE_BUILD_TYPE MATCHES Debug)
     message(WARNING "Intel Compiler and our debugging flags have issues with ADA_Module.f90. So for now we turn off checking compiling ADA_Module.f90")
     set_source_files_properties(ADA_Module.f90 PROPERTIES COMPILE_OPTIONS -nocheck)


### PR DESCRIPTION
I talked to Matt about this, there is a missing line from a prior merge of his; w/o it, CRTM complies but does not run properly in the context of GSI. After talking to Matt, I placed the missing line back.
