### PR TITLE
v12: Fixes for Flang 22

### DIFF
--- a/NCEP_sp/imax_verify.h
+++ b/NCEP_sp/imax_verify.h
@@ -19,19 +19,19 @@
 	subroutine exitn_(mp,n,im)
 	  implicit none
 	  integer,intent(in) :: mp,n,im
-	  integer*4 :: ierr=2
+	  integer :: ierr=2
 
 	  write(*,'(a,3(a,i5))') 'spffte(): -- ERROR -- ',
      &      'invalid imax =',im,', power of factor ',mp, ' is ',n
-          call exit(ierr)
+          stop ierr
 	end subroutine exitn_
 	subroutine exitm_(m,im)
 	  implicit none
 	  integer,intent(in) :: m,im
-	  integer*4 :: ierr=2
+	  integer :: ierr=2
 	  write(*,'(a,3(a,i5))') 'spffte(): -- ERROR -- ',
      &      'invalid imax =',im,', non-factorized number =',m
-          call exit(ierr)
+          stop ierr
 	end subroutine exitm_
 	subroutine factor_get_(m,mp,n)
 	  implicit none

--- a/NCEP_sp/splat.f
+++ b/NCEP_sp/splat.f
@@ -26,7 +26,7 @@ C   97-10-20  IREDELL  ADJUST PRECISION
 C   98-06-11  IREDELL  GENERALIZE PRECISION USING FORTRAN 90 INTRINSIC
 C 1998-12-03  IREDELL  GENERALIZE PRECISION FURTHER
 C 1998-12-03  IREDELL  USE BLAS CALLS
-C 2007-04-26  YANG     FOR EQUALLY-SPACED GRID EXCLUDING POLES, CHANGE 
+C 2007-04-26  YANG     FOR EQUALLY-SPACED GRID EXCLUDING POLES, CHANGE
 c                      DIMENSION OF A FEW ARRAYS
 C 2008-04-08  Todling  Replaced errexit() with exit()
 C
@@ -206,7 +206,7 @@ C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	subroutine die_at_dgesv_messages_(INFO)
 	integer(4),intent(in) :: INFO
 
-	integer(4),parameter :: IEXIT=2
+	integer,parameter :: IEXIT=2
 
 	if(INFO<0) then
 	  write(*,*) "NCEP_sp/splat(): >>>> ERROR <<<< the ",
@@ -218,6 +218,6 @@ C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
      &		INFO,",",INFO,") is singular"
 	endif
 
-	call exit(IEXIT)
+	stop IEXIT
 	end subroutine die_at_dgesv_messages_
       END

--- a/NCEP_w3/errexit.f
+++ b/NCEP_w3/errexit.f
@@ -27,7 +27,7 @@ C   MACHINE: IBM SP
 C
 C$$$
       INTEGER IRET
-      INTEGER(4) JRET
+      INTEGER JRET
       JRET=IRET
-      CALL exit(JRET)
+      stop JRET
       END


### PR DESCRIPTION
This PR has updates for flang 22.

This pull request updates several Fortran routines to improve compatibility and consistency by replacing the use of the `exit` intrinsic with the `stop` statement, and by standardizing integer declarations. These changes help ensure that error handling is more portable across different Fortran compilers and environments.

Error handling and portability improvements:

* Replaced instances of `call exit(...)` with `stop ...` in the routines `exitn_`, `exitm_`, `die_at_dgesv_messages_`, and `ERREXIT`, improving portability and simplifying error exits. [[1]](diffhunk://#diff-bc56d711ed0526957fac797116c92c8f60bc0be7b002a137512ed56dd9c527a4L22-R34) [[2]](diffhunk://#diff-b4d99dbfd9db58cd84d2807aedb62fccface2ca7048c26ffc3697e75706268dbL221-R221) [[3]](diffhunk://#diff-bbffddfd6b16e446b6399d1bd10f4114f073b2b284cb4d1f259feea6a2fd9747L30-R32)
* Standardized integer declarations by removing explicit `integer*4` and `integer(4)` types in favor of default `integer` types in error handling variables, ensuring consistency across routines. [[1]](diffhunk://#diff-bc56d711ed0526957fac797116c92c8f60bc0be7b002a137512ed56dd9c527a4L22-R34) [[2]](diffhunk://#diff-b4d99dbfd9db58cd84d2807aedb62fccface2ca7048c26ffc3697e75706268dbL209-R209) [[3]](diffhunk://#diff-bbffddfd6b16e446b6399d1bd10f4114f073b2b284cb4d1f259feea6a2fd9747L30-R32)